### PR TITLE
Bump maven-surefire-plugin from 3.0.0-M6 to 3.0.0-M7 (#73)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M6</version>
+                <version>3.0.0-M7</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
be able to deobf optifine